### PR TITLE
adds get_resource method

### DIFF
--- a/Log/MonologWriter.php
+++ b/Log/MonologWriter.php
@@ -125,18 +125,8 @@ class MonologWriter
 	 */
 	public function write($object, $level)
 	{
-		if ( !$this->resource )
-		{
-			// create a log channel
-			$this->resource = new \Monolog\Logger($this->settings['name']);
-			foreach ( $this->settings['handlers'] as $handler )
-				$this->resource->pushHandler($handler);
-			foreach ( $this->settings['processors'] as $processor )
-				$this->resource->pushProcessor($processor);
-		}
-
 		// Don't bother typesetting $object, Monolog will do this for us
-		$this->resource->addRecord(
+		$this->get_resource()->addRecord(
 			$this->get_log_level($level, \Monolog\Logger::WARNING),
 			$object
 		);
@@ -163,6 +153,15 @@ class MonologWriter
 	*/
 	public function get_resource()
 	{
+		if ( !$this->resource )
+		{
+			// create a log channel
+			$this->resource = new \Monolog\Logger($this->settings['name']);
+			foreach ( $this->settings['handlers'] as $handler )
+				$this->resource->pushHandler($handler);
+			foreach ( $this->settings['processors'] as $processor )
+				$this->resource->pushProcessor($processor);
+		}		
 		return $this->resource;
 	}
 }

--- a/Log/MonologWriter.php
+++ b/Log/MonologWriter.php
@@ -155,4 +155,14 @@ class MonologWriter
 			$this->log_level[$slim_log_level] :
 			$default_monolog_log_level;
 	}
+	
+	/**
+	* Returns the Logger resource
+	*
+	* @return [\Monolog\Logger] the Logger instance
+	*/
+	public function get_resource()
+	{
+		return $this->resource;
+	}
 }


### PR DESCRIPTION
adds a public method to retrieve the instanced \Monolog\Logger object, to access its methods.

This is because, since [Monolog#658](https://github.com/Seldaek/monolog/pull/658), it's possible to configure the Logger instance to avoid using microsecond resolution timestamps, saving a few milliseconds on a middle sized PHP app.

